### PR TITLE
add watches to GET /{topic}/watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+notifications.db
+webhook-logger

--- a/main.go
+++ b/main.go
@@ -63,8 +63,8 @@ func serve(addr string, store notificationStore, pushInterval time.Duration) err
 			return
 		}
 
-		genID := r.FormValue("generationID")
-		fromIdx := r.FormValue("fromIndex")
+		genID := r.URL.Query().Get("generationID")
+		fromIdx := r.URL.Query().Get("fromIndex")
 
 		if fromIdx == "" {
 			fromIdx = "0"

--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/gorilla/mux"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 // A NotificationsResponse contains a sequence of notifications for a given generation ID.
@@ -95,8 +96,8 @@ func serve(addr string, store notificationStore, pushInterval time.Duration) err
 		}
 	}).Methods("GET")
 
-	watchManager := NewWatchManager(store, pushInterval)
-	r.HandleFunc("/{topic}/watch", watchManager.HandleWatchRequest)
+	watchManager := newWatchManager(store, pushInterval)
+	r.HandleFunc("/{topic}/watch", watchManager.handleWatchRequest)
 
 	return http.ListenAndServe(addr, r)
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func (js JSONString) MarshalJSON() ([]byte, error) {
 	return []byte(js), nil
 }
 
-func serve(addr string, store notificationStore) error {
+func serve(addr string, store notificationStore, pushInterval time.Duration) error {
 	r := mux.NewRouter()
 	r.HandleFunc("/topics/{topic}", func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
@@ -96,6 +96,9 @@ func serve(addr string, store notificationStore) error {
 		}
 	}).Methods("GET")
 
+	watchManager := NewWatchManager(store, pushInterval)
+	r.HandleFunc("/{topic}/watch", watchManager.HandleWatchRequest)
+
 	return http.ListenAndServe(addr, r)
 }
 
@@ -104,6 +107,7 @@ func main() {
 	listenAddr := flag.String("listen-address", ":9099", "The address to listen on for web requests.")
 	retention := flag.Duration("retention", 24*time.Hour, "The retention time after which stored notifications will be purged.")
 	gcInterval := flag.Duration("gc-interval", 10*time.Minute, "The interval at which to run garbage collection cycles to purge old entries.")
+	pushInterval := flag.Duration("push-interval", 5*time.Second, "The interval at which to push messages to websocket clients.")
 	flag.Parse()
 
 	store, err := newBoltStore(&boltStoreOptions{
@@ -118,5 +122,5 @@ func main() {
 	defer store.close()
 
 	log.Printf("Listening on %v...", *listenAddr)
-	log.Fatalln(serve(*listenAddr, store))
+	log.Fatalln(serve(*listenAddr, store, *pushInterval))
 }

--- a/main.go
+++ b/main.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/gorilla/mux"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
-
-	"github.com/gorilla/mux"
 )
 
 // A NotificationsResponse contains a sequence of notifications for a given generation ID.

--- a/watches.go
+++ b/watches.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"net/http"
+	"fmt"
+	"github.com/gorilla/websocket"
+	"log"
+	"time"
+	"strconv"
+	"github.com/gorilla/mux"
+)
+
+type WatchManager struct {
+	upgrader *websocket.Upgrader
+	store notificationStore
+	pushInterval time.Duration
+}
+
+func NewWatchManager(store notificationStore, pushInterval time.Duration) *WatchManager {
+	return &WatchManager{
+		upgrader: &websocket.Upgrader{},
+		store: store,
+		pushInterval: pushInterval,
+	}
+}
+
+func (wm *WatchManager) HandleWatchRequest(w http.ResponseWriter, r *http.Request){
+	topic, ok := mux.Vars(r)["topic"]
+	if !ok {
+		log.Printf("error: topic not provided")
+		http.Error(w, "must provide topic", http.StatusBadRequest)
+		return
+	}
+	log.Printf("TODO: use topics: %v", topic)
+
+	conn, err := wm.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("failed to upgrade HTTP connection: %v", err)
+		http.Error(w, fmt.Sprintf("failed to upgrade HTTP connection: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+
+	genID := r.URL.Query().Get("generationID")
+	fromIdx := r.URL.Query().Get("fromIndex")
+
+	if fromIdx == "" {
+		fromIdx = "0"
+	}
+
+	idx, err := strconv.ParseUint(fromIdx, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid 'fromIndex': %v", err), http.StatusBadRequest)
+		return
+	}
+
+	go wm.manageWatch(conn, genID, idx)
+}
+
+func (wm *WatchManager) manageWatch(conn *websocket.Conn, genID string, idx uint64) {
+	log.Printf("connection accepted from %v", conn.RemoteAddr())
+	defer closeConn(conn)
+	for {
+		notificationResponse, err := wm.store.get(genID, idx)
+		if err != nil {
+			handleError(err, conn)
+			return
+		}
+		if err := conn.WriteJSON(notificationResponse); err != nil {
+			handleError(err, conn)
+			return
+		}
+		time.Sleep(wm.pushInterval)
+	}
+}
+
+func closeConn(conn *websocket.Conn) {
+	log.Printf("terminating connection to %v", conn.RemoteAddr())
+	if err := conn.Close(); err != nil {
+		log.Printf("[WARNING] error closing connection: %v", err)
+	}
+}
+
+func handleError(err error, conn *websocket.Conn) error {
+	log.Printf("closing connection due to error: %v", err)
+	return conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, err.Error()))
+}

--- a/watches.go
+++ b/watches.go
@@ -31,7 +31,6 @@ func (wm *WatchManager) HandleWatchRequest(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "must provide topic", http.StatusBadRequest)
 		return
 	}
-	log.Printf("TODO: use topics: %v", topic)
 
 	conn, err := wm.upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -53,14 +52,14 @@ func (wm *WatchManager) HandleWatchRequest(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	go wm.manageWatch(conn, genID, idx)
+	go wm.manageWatch(conn, topic, genID, idx)
 }
 
-func (wm *WatchManager) manageWatch(conn *websocket.Conn, genID string, idx uint64) {
+func (wm *WatchManager) manageWatch(conn *websocket.Conn, topic, genID string, idx uint64) {
 	log.Printf("connection accepted from %v", conn.RemoteAddr())
 	defer closeConn(conn)
 	for {
-		notificationResponse, err := wm.store.get(genID, idx)
+		notificationResponse, err := wm.store.get(topic, genID, idx)
 		if err != nil {
 			handleError(err, conn)
 			return

--- a/watches_test.go
+++ b/watches_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/gorilla/websocket"
+	"net/http/httptest"
+	"net/url"
+	"time"
+	"github.com/gorilla/mux"
+)
+
+var subject = "WatchManager"
+
+type testNotificationStore struct {
+	notifications []Notification
+}
+
+func (s *testNotificationStore) append(v interface{}) error {
+	s.notifications = append(s.notifications, Notification{
+		Index:     uint64(len(s.notifications)),
+		Timestamp: time.Now(),
+		Data:      v,
+	})
+	return nil
+}
+
+func (s *testNotificationStore) get(generationID string, fromIndex uint64) (*NotificationsResponse, error) {
+	i := int(fromIndex)
+	return &NotificationsResponse{
+		GenerationID:  generationID,
+		Notifications: s.notifications[i:],
+	}, nil
+}
+
+func (s *testNotificationStore) close() error {
+	return nil
+}
+
+func TestWatch(t *testing.T) {
+	var tests = []struct {
+		Context      string
+		Expectation  string
+		MessageCount int
+		MessageDelay time.Duration
+		PollInterval time.Duration
+	}{
+		{
+			Context:      "New messages created every 1s",
+			Expectation:  "send messages to client every pollInterval",
+			MessageCount: 10,
+			MessageDelay: time.Second,
+			PollInterval: time.Second * 2,
+		},
+	}
+
+	for _, test := range tests {
+		runWatchTest(t, test)
+	}
+}
+
+func runWatchTest(t *testing.T, test struct {
+	Context      string
+	Expectation  string
+	MessageCount int
+	MessageDelay time.Duration
+	PollInterval time.Duration
+}) {
+	t.Logf("When %s, %s should %s", test.Context, subject, test.Expectation)
+
+	store := &testNotificationStore{}
+	dialer := websocket.DefaultDialer
+	r := mux.NewRouter()
+	watchManager := NewWatchManager(store, test.PollInterval)
+
+	r.HandleFunc("/{topic}/watch", watchManager.HandleWatchRequest)
+	server := httptest.NewServer(r)
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	u.Scheme = "ws"
+	u.Path = "/mytopic/watch"
+
+	conn, resp, err := dialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error connecting: %v\nresponse: %#v", err, resp)
+	}
+	messageChan := make(chan *NotificationsResponse)
+	go func() {
+		defer close(messageChan)
+		for {
+			var notificationsResponse *NotificationsResponse
+			if err := conn.ReadJSON(&notificationsResponse); err != nil {
+				return
+			}
+			messageChan <- notificationsResponse
+		}
+	}()
+
+	submittedMessages := []string{}
+	go func() {
+		for i := 0; i < test.MessageCount; i++ {
+			item := fmt.Sprintf("message #%v", i)
+			store.append(item)
+			submittedMessages = append(submittedMessages, item)
+			time.Sleep(test.MessageDelay)
+		}
+	}()
+
+	receivedItems := 0
+	select {
+	case <-time.After((test.PollInterval + test.MessageDelay) * time.Duration(test.MessageCount)):
+		t.Fatal("timed out waiting for messages to be received")
+	case notificationsResponse := <-messageChan:
+		for _, notification := range notificationsResponse.Notifications {
+			item := notification.Data.(string)
+			if item != submittedMessages[receivedItems] {
+				t.Fatalf("expected received message %s to equal sent message %s", item, submittedMessages[receivedItems])
+			}
+			receivedItems++
+			if receivedItems == test.MessageCount {
+				return
+			}
+		}
+	}
+}

--- a/watches_test.go
+++ b/watches_test.go
@@ -17,7 +17,7 @@ type testNotificationStore struct {
 	notifications []Notification
 }
 
-func (s *testNotificationStore) append(v interface{}) error {
+func (s *testNotificationStore) append(topic string, v interface{}) error {
 	s.notifications = append(s.notifications, Notification{
 		Index:     uint64(len(s.notifications) + 1),
 		Timestamp: time.Now(),
@@ -26,7 +26,7 @@ func (s *testNotificationStore) append(v interface{}) error {
 	return nil
 }
 
-func (s *testNotificationStore) get(generationID string, fromIndex uint64) (*NotificationsResponse, error) {
+func (s *testNotificationStore) get(topic string, generationID string, fromIndex uint64) (*NotificationsResponse, error) {
 	i := int(fromIndex)
 	return &NotificationsResponse{
 		GenerationID:  generationID,
@@ -101,7 +101,7 @@ func runWatchTest(t *testing.T, test struct {
 	go func() {
 		for i := 0; i < test.MessageCount; i++ {
 			item := fmt.Sprintf("{test packet #%v}", i)
-			store.append(item)
+			store.append("testtopic", item)
 			submittedMessages = append(submittedMessages, item)
 			time.Sleep(test.MessageDelay)
 		}


### PR DESCRIPTION
adds support for streaming notifications via a watch endpoint. uses websocket as transport to establish a long-lived connection with client